### PR TITLE
LittleWireM support for ATtiny85 and friends

### DIFF
--- a/Adafruit_MLX90614.cpp
+++ b/Adafruit_MLX90614.cpp
@@ -24,7 +24,11 @@ Adafruit_MLX90614::Adafruit_MLX90614(uint8_t i2caddr) {
 
 
 boolean Adafruit_MLX90614::begin(void) {
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)  || (__AVR_ATtiny167__)
+ TinyWireM.begin();
+#else 
   Wire.begin();
+#endif
 
   /*
   for (uint8_t i=0; i<0x20; i++) {
@@ -70,6 +74,17 @@ float Adafruit_MLX90614::readTemp(uint8_t reg) {
 uint16_t Adafruit_MLX90614::read16(uint8_t a) {
   uint16_t ret;
 
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)  || (__AVR_ATtiny167__)
+  TinyWireM.beginTransmission(_addr); // start transmission to device 
+  TinyWireM.write(a); // sends register address to read from
+  TinyWireM.endTransmission(false); // end transmission
+  
+  TinyWireM.requestFrom(_addr, (uint8_t)3);// send data n-bytes read
+  ret = TinyWireM.read(); // receive DATA
+  ret |= TinyWireM.read() << 8; // receive DATA
+
+  uint8_t pec = TinyWireM.read();
+#else 
   Wire.beginTransmission(_addr); // start transmission to device 
   Wire.write(a); // sends register address to read from
   Wire.endTransmission(false); // end transmission
@@ -79,6 +94,7 @@ uint16_t Adafruit_MLX90614::read16(uint8_t a) {
   ret |= Wire.read() << 8; // receive DATA
 
   uint8_t pec = Wire.read();
+#endif
 
   return ret;
 }

--- a/Adafruit_MLX90614.h
+++ b/Adafruit_MLX90614.h
@@ -21,7 +21,12 @@
 #else
  #include "WProgram.h"
 #endif
-#include "Wire.h"
+
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)  || (__AVR_ATtiny167__)
+ #include "TinyWireM.h"      // include this if ATtiny85 or ATtiny2313
+#else 
+ #include <Wire.h>           // original lib include
+#endif
 
 
 #define MLX90614_I2CADDR 0x5A


### PR DESCRIPTION
This, combined with https://github.com/digistump/DigistumpArduino/issues/6 will enable the MLX90614 to (easily) work with the Digispark by using the LittleWireM library instead of Wire when compiling for an ATtiny85/2313/167.

I think it will enable the library to work on the Trinket & Gemma as well, but there may be some other things there that make this unnecessary there (I'm not sure either way.)
