### PR TITLE
formatting, fix requestFrom compiler warning with a cast

### DIFF
--- a/Adafruit_MLX90614.cpp
+++ b/Adafruit_MLX90614.cpp
@@ -1,4 +1,4 @@
-/*************************************************** 
+/***************************************************
   This is a library for the MLX90614 Temp Sensor
 
   Designed specifically to work with the MLX90614 sensors in the
@@ -6,22 +6,19 @@
   ----> https://www.adafruit.com/products/1748
   ----> https://www.adafruit.com/products/1749
 
-  These sensors use I2C to communicate, 2 pins are required to  
+  These sensors use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
 #include "Adafruit_MLX90614.h"
 
-Adafruit_MLX90614::Adafruit_MLX90614(uint8_t i2caddr) {
-  _addr = i2caddr;
-}
-
+Adafruit_MLX90614::Adafruit_MLX90614(uint8_t i2caddr) { _addr = i2caddr; }
 
 boolean Adafruit_MLX90614::begin(void) {
   Wire.begin();
@@ -37,11 +34,9 @@ boolean Adafruit_MLX90614::begin(void) {
 
 //////////////////////////////////////////////////////
 
-
 double Adafruit_MLX90614::readObjectTempF(void) {
   return (readTemp(MLX90614_TOBJ1) * 9 / 5) + 32;
 }
-
 
 double Adafruit_MLX90614::readAmbientTempF(void) {
   return (readTemp(MLX90614_TA) * 9 / 5) + 32;
@@ -51,17 +46,16 @@ double Adafruit_MLX90614::readObjectTempC(void) {
   return readTemp(MLX90614_TOBJ1);
 }
 
-
 double Adafruit_MLX90614::readAmbientTempC(void) {
   return readTemp(MLX90614_TA);
 }
 
 float Adafruit_MLX90614::readTemp(uint8_t reg) {
   float temp;
-  
+
   temp = read16(reg);
   temp *= .02;
-  temp  -= 273.15;
+  temp -= 273.15;
   return temp;
 }
 
@@ -70,13 +64,13 @@ float Adafruit_MLX90614::readTemp(uint8_t reg) {
 uint16_t Adafruit_MLX90614::read16(uint8_t a) {
   uint16_t ret;
 
-  Wire.beginTransmission(_addr); // start transmission to device 
-  Wire.write(a); // sends register address to read from
-  Wire.endTransmission(false); // end transmission
-  
-  Wire.requestFrom(_addr, (uint8_t)3);// send data n-bytes read
-  ret = Wire.read(); // receive DATA
-  ret |= Wire.read() << 8; // receive DATA
+  Wire.beginTransmission(_addr); // start transmission to device
+  Wire.write(a);                 // sends register address to read from
+  Wire.endTransmission(false);   // end transmission
+
+  Wire.requestFrom(_addr, (size_t)3); // send data n-bytes read
+  ret = Wire.read();                  // receive DATA
+  ret |= Wire.read() << 8;            // receive DATA
 
   uint8_t pec = Wire.read();
 

--- a/Adafruit_MLX90614.h
+++ b/Adafruit_MLX90614.h
@@ -1,4 +1,4 @@
-/*************************************************** 
+/***************************************************
   This is a library for the MLX90614 Temp Sensor
 
   Designed specifically to work with the MLX90614 sensors in the
@@ -6,23 +6,21 @@
   ----> https://www.adafruit.com/products/1748
   ----> https://www.adafruit.com/products/1749
 
-  These sensors use I2C to communicate, 2 pins are required to  
+  These sensors use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
   Written by Limor Fried/Ladyada for Adafruied in any redistribution
  ****************************************************/
 
-
 #if (ARDUINO >= 100)
- #include "Arduino.h"
+#include "Arduino.h"
 #else
- #include "WProgram.h"
+#include "WProgram.h"
 #endif
 #include "Wire.h"
-
 
 #define MLX90614_I2CADDR 0x5A
 
@@ -45,9 +43,8 @@
 #define MLX90614_ID3 0x3E
 #define MLX90614_ID4 0x3F
 
-
-class Adafruit_MLX90614  {
- public:
+class Adafruit_MLX90614 {
+public:
   Adafruit_MLX90614(uint8_t addr = MLX90614_I2CADDR);
   boolean begin();
   uint32_t readID(void);
@@ -57,11 +54,10 @@ class Adafruit_MLX90614  {
   double readObjectTempF(void);
   double readAmbientTempF(void);
 
- private:
+private:
   float readTemp(uint8_t reg);
 
   uint8_t _addr;
   uint16_t read16(uint8_t addr);
   void write16(uint8_t addr, uint16_t data);
 };
-


### PR DESCRIPTION
This patch fixes the compiler warning from issue #9 

Also formatted with `clang-format` while I was at it