### PR TITLE
Add read/write Config Register1

### DIFF
--- a/Adafruit_MLX90614.h
+++ b/Adafruit_MLX90614.h
@@ -45,6 +45,32 @@
  */
 class Adafruit_MLX90614 {
 public:
+  /**
+   * @brief FIR filter mode (limit the noise)
+   */
+  enum noise_filter_mode {
+    NOISE_LIMIT_128    = 0b10000000000, ///< Low noise filter, FIR = 128
+    NOISE_LIMIT_256    = 0b10100000000, ///< FIR = 256
+    NOISE_LIMIT_512    = 0b11000000000, ///< FIR = 512
+    NOISE_LIMIT_1024   = 0b11100000000, ///< Max noise filter, FIR = 1024, default
+    NOISE_FILTER_ERROR = 0              ///< Error value
+  };
+
+  /**
+   * @brief IIR filter mode (limit the sharpness / spikes)
+   */
+  enum spike_filter_mode {
+    SPIKE_LIMIT_100    = 0b100, ///< No spike reduction, a1 = 1, b1 = 0
+    SPIKE_LIMIT_80     = 0b101, ///< 80% default spike filter, a1 = 0.8, b1 = 0.2
+    SPIKE_LIMIT_67     = 0b110, ///< 67% spike filter, a1 = 0.666, b1 = 0.333
+    SPIKE_LIMIT_57     = 0b111, ///< 57% spike filter, a1 = 0.571, b1 = 0.428
+    SPIKE_LIMIT_50     = 0b000, ///< 50% spike filter, a1 = 0.5, b1 = 0.5
+    SPIKE_LIMIT_25     = 0b001, ///< 25% spike filter, a1 = 0.25, b1 = 0.75
+    SPIKE_LIMIT_17     = 0b010, ///< 17% spike filter, a1 = 0.1666(6), b1 = 0.83(3)
+    SPIKE_LIMIT_13     = 0b011, ///< 13% maximum spike reduction, a1 = 0.125, b1 = 0.875
+    SPIKE_FILTER_ERROR = 0b1000 ///< Error value
+  };
+
   bool begin(uint8_t addr = MLX90614_I2CADDR, TwoWire *wire = &Wire);
 
   double readObjectTempC(void);
@@ -55,6 +81,19 @@ public:
   void writeEmissivityReg(uint16_t ereg);
   double readEmissivity(void);
   void writeEmissivity(double emissivity);
+
+  uint16_t readConfigReg(void);
+  void writeConfigReg(uint16_t creg);
+
+  noise_filter_mode readNoiseFilterMode(void);
+  void writeNoiseFilterMode(noise_filter_mode mode);
+
+  spike_filter_mode readSpikeFilterMode(void);
+  void writeSpikeFilterMode(spike_filter_mode mode);
+
+  void writeFilterMode(noise_filter_mode noise, spike_filter_mode spike);
+
+  unsigned long settlingTime(void);
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface


### PR DESCRIPTION
* Add functions for r/w Config Register1;
* Add functions for r/w FIR (noise) filter settings;
* Add functions for r/w IIR (spike) filter settings;
* Add settling time calculation based on FIR/IIR settings.

FIR/IIR filter settings described in MLX90614ESF datasheet and in "Understanding MLX90614 on-chip digital signal filters".
