### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_MLX90614.cpp
+++ b/Adafruit_MLX90614.cpp
@@ -18,6 +18,11 @@
 
 #include "Adafruit_MLX90614.h"
 
+Adafruit_MLX90614::~Adafruit_MLX90614() {
+  if (i2c_dev)
+    delete i2c_dev;
+}
+
 /**
  * @brief Begin the I2C connection
  * @param addr I2C address for the device.
@@ -26,6 +31,8 @@
  */
 bool Adafruit_MLX90614::begin(uint8_t addr, TwoWire *wire) {
   _addr = addr; // needed for CRC
+  if (i2c_dev)
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(addr, wire);
   return i2c_dev->begin();
 }

--- a/Adafruit_MLX90614.h
+++ b/Adafruit_MLX90614.h
@@ -45,6 +45,7 @@
  */
 class Adafruit_MLX90614 {
 public:
+  ~Adafruit_MLX90614();
   bool begin(uint8_t addr = MLX90614_I2CADDR, TwoWire *wire = &Wire);
 
   double readObjectTempC(void);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MLX90614 Library
-version=2.1.2
+version=2.1.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the MLX90614 sensors in the Adafruit shop


### PR DESCRIPTION
Tested with Qt PY.
```cpp
#include <Adafruit_MLX90614.h>

Adafruit_MLX90614 mlx = Adafruit_MLX90614();

void setup() {
  Serial.begin(9600);
  while (!Serial);
  
  Serial.println("Adafruit MLX90614 multi begin() test");
}

void loop() {
  if (!mlx.begin()) {
    Serial.println("Error connecting to MLX sensor. Check wiring.");
    while (1);
  };
 
  Serial.print("Ambient = "); Serial.print(mlx.readAmbientTempC());
  Serial.print("*C\tObject = "); Serial.print(mlx.readObjectTempC()); Serial.println("*C");
  Serial.print("Ambient = "); Serial.print(mlx.readAmbientTempF());
  Serial.print("*F\tObject = "); Serial.print(mlx.readObjectTempF()); Serial.println("*F");

  Serial.println();
  delay(1000);
}
```

![Screenshot from 2021-08-24 12-33-49](https://user-images.githubusercontent.com/8755041/130678883-7d7fb01b-c696-4db2-b949-2e33088a65f1.png)
