### PR TITLE
Add functions to read raw IR channels 1 and 2

### DIFF
--- a/Adafruit_MLX90614.cpp
+++ b/Adafruit_MLX90614.cpp
@@ -138,6 +138,29 @@ uint16_t Adafruit_MLX90614::read16(uint8_t a) {
   return uint16_t(buffer[0]) | (uint16_t(buffer[1]) << 8);
 }
 
+int16_t Adafruit_MLX90614::readSignMag16(uint8_t a) {
+  uint8_t buffer[3];
+  buffer[0] = a;
+  // read two bytes of data + pec
+  bool status = i2c_dev->write_then_read(buffer, 1, buffer, 3);
+  if (!status)
+    return 0;
+  // return data, ignore pec
+
+  uint16_t magnitude = ((uint16_t)buffer[0] << 8) | buffer[1];
+  // Clear the sign bit
+  magnitude &= ~(1 << 15);
+
+  // Check if the sign bit was set
+  if (buffer[0] & 0x80) {
+    // Negative value
+    return -magnitude;
+  } else {
+    // Positive value
+    return magnitude;
+  }
+}
+
 byte Adafruit_MLX90614::crc8(byte *addr, byte len)
 // The PEC calculation includes all bits except the START, REPEATED START, STOP,
 // ACK, and NACK bits. The PEC is a CRC-8 with polynomial X8+X2+X1+1.

--- a/Adafruit_MLX90614.cpp
+++ b/Adafruit_MLX90614.cpp
@@ -125,6 +125,14 @@ float Adafruit_MLX90614::readTemp(uint8_t reg) {
   return temp;
 }
 
+int16_t Adafruit_MLX90614::readRawIR1(void) {
+  return readSignMag16(MLX90614_RAWIR1);
+}
+
+int16_t Adafruit_MLX90614::readRawIR2(void) {
+  return readSignMag16(MLX90614_RAWIR2);
+}
+
 /*********************************************************************/
 
 uint16_t Adafruit_MLX90614::read16(uint8_t a) {

--- a/Adafruit_MLX90614.h
+++ b/Adafruit_MLX90614.h
@@ -53,15 +53,16 @@ public:
   double readObjectTempF(void);
   double readAmbientTempF(void);
   uint16_t readEmissivityReg(void);
+  int16_t readRawIR1(void);
+  int16_t readRawIR2(void);
   void writeEmissivityReg(uint16_t ereg);
   double readEmissivity(void);
   void writeEmissivity(double emissivity);
-  int16_t readSignMag16(uint8_t addr);
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   float readTemp(uint8_t reg);
-
+  int16_t readSignMag16(uint8_t addr);
   uint16_t read16(uint8_t addr);
   void write16(uint8_t addr, uint16_t data);
   byte crc8(byte *addr, byte len);

--- a/Adafruit_MLX90614.h
+++ b/Adafruit_MLX90614.h
@@ -56,6 +56,7 @@ public:
   void writeEmissivityReg(uint16_t ereg);
   double readEmissivity(void);
   void writeEmissivity(double emissivity);
+  int16_t readSignMag16(uint8_t addr);
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface


### PR DESCRIPTION
Implements a function that reads the raw values from RAM and converts it, following the "sign-magnitude representation" according to the sensor's manual.

Solves issue #46.